### PR TITLE
Fix imageView layout

### DIFF
--- a/Sources/DarkRoom/Carousel/DarkRoomCarouselViewController.swift
+++ b/Sources/DarkRoom/Carousel/DarkRoomCarouselViewController.swift
@@ -29,7 +29,7 @@ import UIKit
 /// A PageController class which is able to show image or video
 public final class DarkRoomCarouselViewController: UIPageViewController {
 
-    public var shouldLayoutImageViewInViewDidLoad = false
+    private let shouldLayoutImageViewInViewDidLoad: Bool
 
     // MARK: - Dependencies
 
@@ -100,7 +100,7 @@ public final class DarkRoomCarouselViewController: UIPageViewController {
         imageLoader: DarkRoomImageLoader,
         initialIndex: Int = 0,
         configuration: DarkRoomCarouselConfiguration = DarkRoomCarouselDefaultConfiguration(),
-        shouldLayoutImageViewInViewDidLoad: Bool
+        shouldLayoutImageViewInViewDidLoad: Bool = false
     ) {
         self.initialIndex = initialIndex
         self.displayedIndex = initialIndex

--- a/Sources/DarkRoom/Carousel/DarkRoomCarouselViewController.swift
+++ b/Sources/DarkRoom/Carousel/DarkRoomCarouselViewController.swift
@@ -29,6 +29,8 @@ import UIKit
 /// A PageController class which is able to show image or video
 public final class DarkRoomCarouselViewController: UIPageViewController {
 
+    public var shouldLayoutImageViewInViewDidLoad = false
+
     // MARK: - Dependencies
 
     /// Loading service for images
@@ -97,7 +99,8 @@ public final class DarkRoomCarouselViewController: UIPageViewController {
         imageDelegate: DarkRoomCarouselDelegate? = nil,
         imageLoader: DarkRoomImageLoader,
         initialIndex: Int = 0,
-        configuration: DarkRoomCarouselConfiguration = DarkRoomCarouselDefaultConfiguration()
+        configuration: DarkRoomCarouselConfiguration = DarkRoomCarouselDefaultConfiguration(),
+        shouldLayoutImageViewInViewDidLoad: Bool
     ) {
         self.initialIndex = initialIndex
         self.displayedIndex = initialIndex
@@ -105,6 +108,7 @@ public final class DarkRoomCarouselViewController: UIPageViewController {
         self.mediaDelegate = imageDelegate
         self.imageLoader = imageLoader
         self.configuration = configuration
+        self.shouldLayoutImageViewInViewDidLoad = shouldLayoutImageViewInViewDidLoad
         let pageOptions = [UIPageViewController.OptionsKey.interPageSpacing: 20]
 
         super.init(
@@ -271,7 +275,8 @@ extension DarkRoomCarouselViewController: UIPageViewControllerDataSource {
             index: index,
             imageURL: data.imageUrl,
             imagePlaceholder: data.imagePlaceholder,
-            imageLoader: imageLoader
+            imageLoader: imageLoader,
+            shouldLayoutImageViewInViewDidLoad: shouldLayoutImageViewInViewDidLoad
         )
     }
     
@@ -337,4 +342,3 @@ extension DarkRoomCarouselViewController: DarkRoomTransitionViewControllerConver
         return vc.imageOverlayView
     }
 }
-

--- a/Sources/DarkRoom/ImageView/DarkRoomImageViewerController.swift
+++ b/Sources/DarkRoom/ImageView/DarkRoomImageViewerController.swift
@@ -73,7 +73,9 @@ internal final class DarkRoomImageViewerController: UIViewController, UIGestureR
     private let imageLoader: DarkRoomImageLoader
     
     private var configuration: DarkRoomImageControllerConfiguration
-    
+
+    private let shouldLayoutImageViewInViewDidLoad: Bool
+
     // MARK: - LifeCycle
 
     internal init(
@@ -81,7 +83,8 @@ internal final class DarkRoomImageViewerController: UIViewController, UIGestureR
         imageURL: URL,
         imagePlaceholder: UIImage,
         imageLoader: DarkRoomImageLoader,
-        configuration: DarkRoomImageControllerConfiguration = DarkRoomImageControllerDeafultConfiguration()
+        configuration: DarkRoomImageControllerConfiguration = DarkRoomImageControllerDeafultConfiguration(),
+        shouldLayoutImageViewInViewDidLoad: Bool
     ) {
         self.index = index
         self.imageURL = imageURL
@@ -91,6 +94,7 @@ internal final class DarkRoomImageViewerController: UIViewController, UIGestureR
         self.lastLocation = .zero
         self.isAnimating = false
         self.maxZoomScale = 1.0
+        self.shouldLayoutImageViewInViewDidLoad = shouldLayoutImageViewInViewDidLoad
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -138,6 +142,9 @@ internal final class DarkRoomImageViewerController: UIViewController, UIGestureR
 
     internal override func viewDidLoad() {
         super.viewDidLoad()
+        if shouldLayoutImageViewInViewDidLoad {
+            layout()
+        }
         loadImage()
         addGestureRecognizers()
     }
@@ -337,4 +344,3 @@ extension DarkRoomImageViewerController: UIScrollViewDelegate {
         updateConstraintsForSize(view.bounds.size)
     }
 }
-


### PR DESCRIPTION
The image layout issue before loading (when showing the placeholder) has been fixed.
 This fix is gated behind the `shouldLayoutImageViewInViewDidLoad` flag.
No breaking change